### PR TITLE
adapt pathology detection code to handle three coordinates

### DIFF
--- a/src/unicorn_eval/adaptors/detection.py
+++ b/src/unicorn_eval/adaptors/detection.py
@@ -211,7 +211,7 @@ def assign_cells_to_patches(cell_data, patch_coordinates, patch_size):
     """Assign ROI cell coordinates to the correct patch."""
     patch_cell_map = {i: [] for i in range(len(patch_coordinates))}
 
-    for x, y in cell_data:
+    for x, y, _ in cell_data:
         for i, (x_patch, y_patch) in enumerate(patch_coordinates):
             if (
                 x_patch <= x < x_patch + patch_size


### PR DESCRIPTION
After the integration of radiology vision tasks, ``cell_data`` now returns (x, y, z) coordinates, but the pathology detection pipeline only uses (x, y) coordinates, and the additional z dimension was not properly handled. 