### PR TITLE
Add ConvDetector with hardcoded spatial sizes

### DIFF
--- a/src/unicorn_eval/adaptors/__init__.py
+++ b/src/unicorn_eval/adaptors/__init__.py
@@ -26,7 +26,7 @@ from unicorn_eval.adaptors.regression import (
     MultiLayerPerceptronRegressor,
 )
 
-from unicorn_eval.adaptors.detection import DensityMap, PatchNoduleRegressor
+from unicorn_eval.adaptors.detection import DensityMap, ConvDetector, PatchNoduleRegressor
 from unicorn_eval.adaptors.segmentation import (
     SegmentationUpsampling,
     SegmentationUpsampling3D,
@@ -43,6 +43,7 @@ __all__ = [
     "LinearProbingRegressor",
     "MultiLayerPerceptronRegressor",
     "DensityMap",
+    "ConvDetector",
     "PatchNoduleRegressor",
     "SegmentationUpsampling",
     "SegmentationUpsampling3D",

--- a/src/unicorn_eval/utils.py
+++ b/src/unicorn_eval/utils.py
@@ -22,6 +22,7 @@ from sksurv.metrics import concordance_index_censored
 from unicorn_eval.adaptors import (
     KNN,
     DensityMap,
+    ConvDetector,
     KNNRegressor,
     LinearProbing,
     LinearProbingRegressor,
@@ -313,6 +314,18 @@ def adapt_features(
             test_names=test_names,
             patch_size=patch_size[0],
             heatmap_size=16,
+        )
+
+    elif adaptor_name == "conv-detector":
+        adaptor = ConvDetector(
+            shot_features=shot_features,
+            shot_labels=shot_labels,
+            shot_coordinates=shot_coordinates,
+            shot_names=shot_names,
+            test_features=test_features,
+            test_coordinates=test_coordinates,
+            test_names=test_names,
+            patch_size=patch_size[0]
         )
 
     elif adaptor_name == "segmentation-upsampling":


### PR DESCRIPTION
Name could be: "conv-detector"

The convolutional detector only makes a small change to the 'density map' adapter, replacing the linear layer with a small convolutional stack. 

This could help to solve the problem of the training process on the platform being overwhelmed by lots of patches. It would do this by allowing more feature vectors to be included in a single patch representation.

At the moment, the size of the heatmap is hardcoded to 32 x 32. I have already tested with task05 on a laptop with 16GB of RAM, but I'm not sure if it will run on the platform. Is there a way to read the heatmap size as optional metadata from the "patch-neural-representation.json" file to enable setting this later?