### PR TITLE
Add ConvDecoder3D and ConvSegmentation3D

### DIFF
--- a/src/unicorn_eval/adaptors/__init__.py
+++ b/src/unicorn_eval/adaptors/__init__.py
@@ -30,6 +30,7 @@ from unicorn_eval.adaptors.detection import DensityMap, ConvDetector, PatchNodul
 from unicorn_eval.adaptors.segmentation import (
     SegmentationUpsampling,
     SegmentationUpsampling3D,
+    ConvSegmentation3D,
 )
 
 __all__ = [

--- a/src/unicorn_eval/utils.py
+++ b/src/unicorn_eval/utils.py
@@ -32,6 +32,7 @@ from unicorn_eval.adaptors import (
     PatchNoduleRegressor,
     SegmentationUpsampling,
     SegmentationUpsampling3D,
+    ConvSegmentation3D,
     WeightedKNN,
     WeightedKNNRegressor,
 )
@@ -368,8 +369,63 @@ def adapt_features(
             shot_image_directions=shot_image_directions,
         )
 
+    elif adaptor_name == "conv-segmentation-3d":
+        adaptor = ConvSegmentation3D(  # All args copied from segmentation-upsampling-3d
+            shot_features=shot_features,
+            shot_coordinates=shot_coordinates,
+            shot_names=shot_names,
+            shot_labels=shot_labels,
+            shot_label_spacing=shot_label_spacing,
+            shot_label_origins=shot_label_origins,
+            shot_label_directions=shot_label_directions,
+            test_features=test_features,
+            test_coordinates=test_coordinates,
+            test_names=test_names,  # try to remove this input
+            test_image_sizes=test_image_sizes,
+            test_image_origins=test_image_origins,
+            test_image_spacings=test_image_spacing,
+            test_image_directions=test_image_directions,
+            test_label_sizes=test_label_sizes,
+            test_label_spacing=test_label_spacing,
+            test_label_origins=test_label_origins,
+            test_label_directions=test_label_directions,
+            patch_size=patch_size,
+            shot_image_sizes=shot_image_sizes,
+            shot_image_spacing=shot_image_spacing,
+            shot_image_origins=shot_image_origins,
+            shot_image_directions=shot_image_directions,
+        )
+
     elif adaptor_name == "detection-by-segmentation-upsampling-3d":
         adaptor = SegmentationUpsampling3D(
+            shot_features=shot_features,
+            shot_coordinates=shot_coordinates,
+            shot_names=shot_names,
+            shot_image_sizes=shot_image_sizes,
+            shot_image_spacing=shot_image_spacing,
+            shot_image_origins=shot_image_origins,
+            shot_image_directions=shot_image_directions,
+            shot_labels=shot_labels,
+            shot_label_spacing=shot_label_spacing,
+            shot_label_origins=shot_label_origins,
+            shot_label_directions=shot_label_directions,
+            test_features=test_features,
+            test_coordinates=test_coordinates,
+            test_names=test_names,
+            test_image_sizes=test_image_sizes,
+            test_image_origins=test_image_origins,
+            test_image_spacings=test_image_spacing,
+            test_image_directions=test_image_directions,
+            test_label_sizes=test_label_sizes,
+            test_label_spacing=test_label_spacing,
+            test_label_origins=test_label_origins,
+            test_label_directions=test_label_directions,
+            patch_size=patch_size,
+            return_binary=False,
+        )
+
+    elif adaptor_name == "conv-detection-segmentation-3d":
+        adaptor = ConvSegmentation3D(  # All args copied from detection-by-segmentation-upsampling-3d
             shot_features=shot_features,
             shot_coordinates=shot_coordinates,
             shot_names=shot_names,


### PR DESCRIPTION
- The "conv-segmentation-3d" adaptor reuses the original segmentation-upsampling-3d adaptor and replaces its upsampling with convolution at a small resolution.
- The resolution can optionally be specified with the patchsize like [patchsize 1&2&3] + [resolution 1&2&3].
- Tested with task06, task10 & task11 on a machine with 8GB GPU and 16GB RAM.
- Like the corresponding upsampling adaptor, "conv-detection-segmentation-3d" reuses the segmentation adaptor to return scores instead of predictions.

Currently, the metric for Task 11 compares instance masks. Is this intended?