### PR TITLE
Coordinate Driven Patch Extraction

### DIFF
--- a/src/unicorn_eval/adaptors/patch_extraction.py
+++ b/src/unicorn_eval/adaptors/patch_extraction.py
@@ -1,8 +1,6 @@
 from typing import Iterable
-import numpy as np
 import SimpleITK as sitk
 from picai_prep.preprocessing import resample_img, crop_or_pad
-import itertools
 
 
 def pad_image(image: sitk.Image, patch_size: Iterable[int]) -> sitk.Image:
@@ -34,25 +32,24 @@ def pad_image(image: sitk.Image, patch_size: Iterable[int]) -> sitk.Image:
 
 def extract_patches(
     image: sitk.Image,
+    coordinates: Iterable[tuple[float, float, float]],
     patch_size: Iterable[int],
     spacing: Iterable[float] | None = None,
 ) -> tuple[list[sitk.Image], list[tuple]]:
     """
     Extracts uniformly sized patches from a 3D SimpleITK image, optionally resampling it to a specified voxel spacing before extraction.
-
+    
     If `spacing` is provided, the image is first resampled using linear interpolation to achieve the specified spacing. The image is then padded so that its dimensions become exactly divisible by the given patch size. Patches are extracted systematically, covering the entire image volume without overlap or gaps.
 
     Args:
         image (sitk.Image): Input 3D image from which to extract patches.
+        coordinates (Iterable[tuple[float, float, float]]): Start coordinates for each patch in world coordinates. These are used to determine the physical location of each patch in the original image.
         patch_size (list[int]): Patch size as [x, y, z], defining the dimensions of each extracted patch.
         spacing (list[float] | None, optional): Desired voxel spacing as [x, y, z]. If provided, the image will be resampled to this spacing before patch extraction. Defaults to None.
 
     Returns:
         - patches (list[sitk.Image]): List of extracted image patches.
-        - coordinates (list[tuple]): List of coordinates for each patch, formatted as:
-            ((x_start, y_start, z_start), (x_end, y_end, z_end)) in world coordinates.
-            Each coordinate pair represents the start and end points of the patch in the original image's physical space.
-    """
+     """
     if spacing is not None:
         # resample image to specified spacing
         image = resample_img(
@@ -67,23 +64,13 @@ def extract_patches(
         patch_size=patch_size,
     )
 
-    # generate patch coordinates (x, y, z)
-    image_size = image.GetSize()
-    steps = [range(0, image_size[dim], patch_size[dim]) for dim in range(3)]
-
     patches = []
-    coordinates = []
-    for x, y, z in itertools.product(*steps):
-        start_coords = (x, y, z)
-        patch = sitk.RegionOfInterest(image, patch_size, start_coords)
-        patches.append(patch)
-        matrix_coordinates = (
-            (x, y, z),
-            (x + patch_size[0], y + patch_size[1], z + patch_size[2]),
-        )
-        world_coordinates = tuple(
-            image.TransformIndexToPhysicalPoint(coord) for coord in matrix_coordinates
-        )
-        coordinates.append(world_coordinates)
+    for coord in coordinates:
+        # Convert start coordinate from world space to index space
+        start_index = image.TransformPhysicalPointToIndex(coord)
 
-    return patches, coordinates
+        # Extract ROI
+        patch = sitk.RegionOfInterest(image, patch_size, start_index)
+        patches.append(patch)
+
+    return patches

--- a/src/unicorn_eval/adaptors/segmentation.py
+++ b/src/unicorn_eval/adaptors/segmentation.py
@@ -707,6 +707,7 @@ def extract_patch_labels(
     image_spacing,
     image_origin,
     image_direction,
+    start_coordinates,
     patch_size: list[int] = [16, 256, 256],
     patch_spacing: list[float] | None = None,
 ) -> list[dict]:
@@ -739,8 +740,9 @@ def extract_patch_labels(
 
     patch_features = []
 
-    patches, coordinates = extract_patches(
+    patches = extract_patches(
         image=label,
+        coordinates=start_coordinates,
         patch_size=patch_size,
         spacing=patch_spacing,
     )
@@ -748,12 +750,12 @@ def extract_patch_labels(
         patch_spacing = label.GetSpacing()
 
     for patch, coordinates in tqdm(
-        zip(patches, coordinates), total=len(patches), desc="Extracting features"
+        zip(patches, start_coordinates), total=len(patches), desc="Extracting features"
     ):
         patch_array = sitk.GetArrayFromImage(patch)
         patch_features.append(
             {
-                "coordinates": list(coordinates[0]),  # save the start coordinates
+                "coordinates": list(coordinates),  # save the start coordinates
                 "features": patch_array,
             }
         )
@@ -1251,6 +1253,7 @@ class SegmentationUpsampling3D(PatchLevelTaskAdaptor):
                 image_origin=shot_image_origins[shot_names[idx]],
                 image_spacing=shot_image_spacing[shot_names[idx]],
                 image_direction=shot_image_directions[shot_names[idx]],
+                start_coordinates=shot_coordinates[idx],
                 patch_size=patch_size,
             )
             label_patch_features.append(label_feats)


### PR DESCRIPTION
# Extract patches from provided coordinates

### Problem
The previous implementation did expect the same patch extraction scheme as in the baseline method. If participants used their own patch extraction algorithms (e.g. to allow overlapping patches) that could lead to _AssertionError: Coordinates don't match!_.

### Fix
Now the coordinates in the `patch-neural-representation.json` are used to calculate the corresponding patches. This should work with all submisisons as long as "coordinates", "patch-size", and "patch-spacing" are provided correctly.

### Remark to PR Reviewer
Please check line 1256 in segmentation.py (`start_coordinates=shot_coordinates[idx]`). I'm not 100% sure if I pass the correct start_coordinates to the function.