### PR TITLE
fix: general fix for LinearUpsampleConv3D

### DIFF
--- a/src/unicorn_eval/adaptors/__init__.py
+++ b/src/unicorn_eval/adaptors/__init__.py
@@ -31,7 +31,8 @@ from unicorn_eval.adaptors.segmentation import (
     SegmentationUpsampling,
     SegmentationUpsampling3D,
     ConvSegmentation3D,
-    LinearUpsampleConv3D
+    LinearUpsampleConv3D,
+    Conv3DLineaerUpsample
 )
 
 __all__ = [
@@ -50,5 +51,6 @@ __all__ = [
     "SegmentationUpsampling",
     "SegmentationUpsampling3D",
     "ConvSegmentation3D",
-    "LinearUpsampleConv3D"
+    "LinearUpsampleConv3D",
+    "Conv3DLineaerUpsample"
 ]

--- a/src/unicorn_eval/adaptors/segmentation.py
+++ b/src/unicorn_eval/adaptors/segmentation.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import math
 from collections import defaultdict
 from typing import Iterable
+from scipy import ndimage as ndi
 
 import numpy as np
 import SimpleITK as sitk
@@ -632,6 +633,9 @@ def inference3d(
         return [j for j in aligned_preds.values()]
 
 
+
+
+
 def construct_data_with_labels(
     coordinates,
     embeddings,
@@ -782,409 +786,8 @@ def load_patch_data(data_array: np.ndarray, batch_size: int = 80) -> DataLoader:
     train_loader = dataloader_monai(train_ds, batch_size=batch_size, shuffle=False)
     return train_loader
 
-class LinearUpsampleConv3D(PatchLevelTaskAdaptor):
-    """
-    Patch-level adaptor that performs segmentation by linearly upsampling 
-    3D patch-level features followed by convolutional refinement.
-
-    This adaptor takes precomputed patch-level features from 3D medical images
-    and predicts voxel-wise segmentation by applying a simple decoder that:
-    1) linearly upsamples the patch embeddings to the original resolution, and
-    2) passes them through 3D convolution layers for spatial refinement.
-
-    Steps:
-    1. Extract patch-level segmentation labels using spatial metadata.
-    2. Construct training data from patch features and coordinates.
-    3. Train a lightweight 3D decoder that linearly upsamples features and refines them with convolution layers.
-    4. At inference, apply the decoder to test patch features and reconstruct full-size segmentation predictions.
-
-    Args:
-        shot_features : Patch-level feature embeddings of few-shot labeled volumes.
-        shot_labels : Full-resolution segmentation labels (used to supervise the decoder).
-        shot_coordinates : Patch coordinates corresponding to shot_features.
-        shot_names : Case identifiers for few-shot examples.
-        test_features : Patch-level feature embeddings for testing.
-        test_coordinates : Patch coordinates corresponding to test_features.
-        test_names : Case identifiers for testing examples.
-        test_image_sizes, test_image_origins, test_image_spacings, test_image_directions:
-            Metadata for reconstructing the spatial layout of test predictions.
-        shot_image_spacing, shot_image_origins, shot_image_directions:
-            Metadata used to align segmentation labels with patch features during training.
-        patch_size : Size of each 3D patch.
-        return_binary : Whether to threshold predictions into binary segmentation masks.
-    """
-
-    def __init__(
-        self,
-        shot_features,
-        shot_coordinates,
-        shot_names,
-        shot_labels,
-        shot_image_spacing,
-        shot_image_origins,
-        shot_image_directions,
-        shot_image_sizes,
-        shot_label_spacing,
-        shot_label_origins,
-        shot_label_directions,
-        test_features,
-        test_coordinates,
-        test_names,
-        test_image_sizes,
-        test_image_origins,
-        test_image_spacings,
-        test_image_directions,
-        test_label_sizes,
-        test_label_spacing,
-        test_label_origins,
-        test_label_directions,
-        patch_size,
-        return_binary=True,
-    ):   
-        label_patch_features = []
-        for idx, label in enumerate(shot_labels):
-            label_feats = extract_patch_labels_no_resample(
-                label=label,
-                label_spacing=shot_label_spacing[shot_names[idx]],
-                label_origin=shot_label_origins[shot_names[idx]],
-                label_direction=shot_label_directions[shot_names[idx]],
-                image_size=shot_image_sizes[shot_names[idx]],
-                image_origin=shot_image_origins[shot_names[idx]],
-                image_spacing=shot_image_spacing[shot_names[idx]],
-                image_direction=shot_image_directions[shot_names[idx]],
-                patch_size=patch_size,
-            )
-            label_patch_features.append(label_feats)
-        label_patch_features = np.array(label_patch_features, dtype=object)
-
-        super().__init__(
-            shot_features=shot_features,
-            shot_labels=label_patch_features,
-            shot_coordinates=shot_coordinates,
-            test_features=test_features,
-            test_coordinates=test_coordinates,
-            shot_extra_labels=None,  # not used here
-        )
-
-        self.shot_names = shot_names
-        self.test_cases = test_names
-        self.test_image_sizes = test_image_sizes
-        self.test_image_origins = test_image_origins
-        self.test_image_spacings = test_image_spacings
-        self.test_image_directions = test_image_directions
-        self.shot_image_spacing = shot_image_spacing
-        self.shot_image_origins = shot_image_origins
-        self.shot_image_directions = shot_image_directions
-        self.test_label_sizes = test_label_sizes
-        self.test_label_spacing = test_label_spacing
-        self.test_label_origins = test_label_origins
-        self.test_label_directions = test_label_directions
-        self.patch_size = patch_size
-        self.decoder = None
-        self.return_binary = return_binary
-
-    def fit(self):
-        # build training data and loader
-        train_data = construct_data_with_labels(
-            coordinates=self.shot_coordinates,
-            embeddings=self.shot_features,
-            cases=self.shot_names,
-            patch_size=self.patch_size,
-            labels=self.shot_labels,
-        )
-        train_loader = load_patch_data(train_data, batch_size=1)
-
-        # set up device and model
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-        decoder = LightweightSegAdaptor(
-            target_shape=self.patch_size,
-        )
-
-        decoder.to(self.device)
-        self.decoder = train_seg_adaptor3d(decoder, train_loader, self.device)
-
-    def predict(self) -> np.ndarray:
-        # build test data and loader
-        test_data = construct_data_with_labels(
-            coordinates=self.test_coordinates,
-            embeddings=self.test_features,
-            cases=self.test_cases,
-            patch_size=self.patch_size,
-            image_sizes=self.test_image_sizes,
-            image_origins=self.test_image_origins,
-            image_spacings=self.test_image_spacings,
-            image_directions=self.test_image_directions,
-        )
-
-        test_loader = load_patch_data(test_data, batch_size=1)
-        # run inference using the trained decoder
-
-        return seg_inference3d(self.decoder, test_loader, self.device, self.return_binary, self.test_cases, self.test_label_sizes, self.test_label_spacing, self.test_label_origins, self.test_label_directions)
 
 
-
-def extract_patch_labels_no_resample(
-    label,
-    label_spacing,
-    label_origin,
-    label_direction,
-    image_size,
-    image_spacing,
-    image_origin,
-    image_direction,
-    patch_size: list[int] = [16, 256, 256],
-    patch_spacing: list[float] | None = None,
-) -> list[dict]:
-    """
-    Generate a list of patch features from a radiology image
-
-    Args:
-        image: image object
-        title (str): Title of the patch-level neural representation
-        patch_size (list[int]): Size of the patches to extract
-        patch_spacing (list[float] | None): Voxel spacing of the image. If specified, the image will be resampled to this spacing before patch extraction.
-    Returns:
-        list[dict]: List of dictionaries containing the patch features
-        - coordinates (list[tuple]): List of coordinates for each patch, formatted as:
-            ((x_start, x_end), (y_start, y_end), (z_start, z_end)).
-        - features (list[float]): List of features extracted from the patch
-    """
-    label_array = label.copy()  
-    label = sitk.GetImageFromArray(label)
-    label.SetOrigin(image_origin)
-    label.SetSpacing(image_spacing)
-    label.SetDirection(image_direction)
-
-    # a = np.array_equal(label_array, sitk.GetArrayFromImage(label))
-    patch_features = []
-
-    D, H, W = label_array.shape  # numpy shape: (z, y, x)
-    d, h, w = patch_size
-
-    for z in range(0, D - d + 1, d):
-        for y in range(0, H - h + 1, h):
-            for x in range(0, W - w + 1, w):
-                patch = label_array[z:z + d, y:y + h, x:x + w]
-                corner_index = (x, y, z)
-                physical_coord = label.TransformIndexToPhysicalPoint(corner_index)
-
-                patch_features.append({
-                "coordinates": list(physical_coord),
-                "features": patch
-            })
-
-    if patch_spacing is None:
-        patch_spacing = label.GetSpacing()
-
-    patch_labels = make_patch_level_neural_representation(
-        patch_features=patch_features,
-        patch_size=patch_size,
-        patch_spacing=patch_spacing,
-        image_size=label.GetSize(),
-        image_origin=label.GetOrigin(),
-        image_spacing=label.GetSpacing(),
-        image_direction=label.GetDirection(),
-        title="patch_labels",
-    )
-
-    return patch_labels
-
-
-def seg_inference3d(decoder, data_loader, device, return_binary,  test_cases, test_label_sizes, test_label_spacing, test_label_origins, test_label_directions):
-    decoder.eval()
-    with torch.no_grad():
-        grouped_predictions = defaultdict(lambda: defaultdict(list))
-
-        for batch in data_loader:
-            inputs = batch["patch"].to(device)  # shape: [B, ...]
-            coords = batch["coordinates"]  # list of 3 tensors
-            image_idxs = batch["case_number"]
-
-            outputs = decoder(inputs)  # shape: [B, ...]
-            probs = torch.softmax(outputs, dim=1)  # channel dim = 1
-
-            # probs = torch.sigmoid(outputs)
-            if return_binary:
-                pred_mask = torch.argmax(probs, dim=1).float()
-            else:
-                # pred_mask = probs[:,1:2]
-                raise NotImplementedError(
-                    "seg_inference3d currently supports only return_binary=True. "
-                )
-
-            batch["image_origin"] = batch["image_origin"][0]
-            batch["image_spacing"] = batch["image_spacing"][0]
-            for i in range(len(image_idxs)):
-                image_id = int(image_idxs[i])
-                coord = tuple(
-                    float(c) for c in coords[i]
-                )  # convert list to tuple for use as dict key
-                grouped_predictions[image_id][coord].append(
-                    {
-                        "features": pred_mask[i].cpu().numpy(),
-                        "patch_size": [
-                            int(batch["patch_size"][j][i])
-                            for j in range(len(batch["patch_size"]))
-                        ],
-                        "image_size": [
-                            int(batch["image_size"][j][i])
-                            for j in range(len(batch["image_size"]))
-                        ],
-                        "image_origin": [
-                            float(batch["image_origin"][j][i])
-                            for j in range(len(batch["image_origin"]))
-                        ],
-                        "image_spacing": [
-                            float(batch["image_spacing"][j][i])
-                            for j in range(len(batch["image_spacing"]))
-                        ],
-                        "image_direction": [
-                            float(batch["image_direction"][j][i])
-                            for j in range(len(batch["image_direction"]))
-                        ],
-                    }
-                )
-
-        averaged_patches = defaultdict(list)
-
-        for image_id, coord_dict in grouped_predictions.items():
-            for coord, patches in coord_dict.items():
-                all_features = [p["features"] for p in patches]
-                stacked = np.stack(all_features, axis=0)
-                avg_features = np.mean(stacked, axis=0)
-
-                averaged_patches[image_id].append(
-                    {
-                        "coord": list(coord),
-                        "features": avg_features,
-                        "patch_size": patches[0]["patch_size"],
-                        "image_size": patches[0]["image_size"],
-                        "image_origin": patches[0]["image_origin"],
-                        "image_spacing": patches[0]["image_spacing"],
-                        "image_direction": patches[0]["image_direction"],
-                    }
-                )
-
-        final_images = []
-        for image_id, patch_list in averaged_patches.items():
-            image_size = patch_list[0]["image_size"]  # [Z, Y, X]
-            patch_size = patch_list[0]["patch_size"]  # [D, H, W]
-
-            origin = patch_list[0]["image_origin"]
-            spacing = patch_list[0]["image_spacing"]
-            direction = np.array(patch_list[0]["image_direction"]).reshape(3, 3)
-            inv_direction = np.linalg.inv(direction)
-
-            # Initialize empty volume
-            grid = np.zeros(image_size, dtype=np.float32)
-            count = np.zeros(image_size, dtype=np.float32)  # For averaging overlap
-
-            for patch in patch_list:
-                coord = patch["coord"]
-                patch_data = patch["features"]  # shape: [D, H, W]
-                d, h, w = patch_size
-
-                i, j, k = world_to_voxel(coord, origin, spacing, inv_direction)
-
-         
-                d, h, w = patch["features"].shape
-
-    
-                z_slice = slice(k, k + d)
-                y_slice = slice(j, j + h)
-                x_slice = slice(i, i + w)
-
-                # Accumulate into grid
-                grid[z_slice, y_slice, x_slice] += patch_data
-                count[z_slice, y_slice, x_slice] += 1.0
-
-            # Avoid division by zero
-            count[count == 0] = 1.0
-            final_image = grid / count
-            final_images.append(final_image)
-        return final_images
-
-
-
-class LightweightSegAdaptor(nn.Module):
-    def __init__(self, target_shape=None, in_channels=32, num_classes=2):
-        super().__init__()
-        self.target_shape = target_shape
-        self.in_channels = in_channels
-        # Two intermediate conv layers + final prediction layer
-        self.conv_blocks = nn.Sequential(
-            nn.Conv3d(in_channels, in_channels, kernel_size=3, padding=1),
-            nn.ReLU(inplace=True),
-            nn.Conv3d(in_channels, in_channels, kernel_size=3, padding=1),
-            nn.ReLU(inplace=True),
-            nn.Conv3d(in_channels, num_classes, kernel_size=1)
-            # nn.Conv3d(mid_channels, num_classes, kernel_size=3, padding=1) 
-        )
-        
-    def forward(self, x):
-        C = self.in_channels
-        flat_voxel_count = x.shape[1] // C
-
-        D_ref, H_ref, W_ref = self.target_shape
-        ref_ratio = D_ref * H_ref * W_ref
-
-        k = (flat_voxel_count / ref_ratio) ** (1 / 3)
-
-        D = round(D_ref * k)
-        H = round(H_ref * k)
-        W = round(W_ref * k)
-
-        x = x.view(1, C, D, H, W)
-        x = F.interpolate(x, size=self.target_shape, mode="trilinear", align_corners=False)
-        x = self.conv_blocks(x)
-
-        return x
-
-
-def dice_loss(pred, target, smooth=1e-5):
-    num_classes = pred.shape[1]
-    pred = F.softmax(pred, dim=1)
-    one_hot_target = F.one_hot(target, num_classes=num_classes).permute(0, 4, 1, 2, 3).float()
-
-    intersection = torch.sum(pred * one_hot_target, dim=(2, 3, 4))
-    union = torch.sum(pred + one_hot_target, dim=(2, 3, 4))
-
-    dice = (2 * intersection + smooth) / (union + smooth)
-    return 1 - dice.mean()
-
-
-def train_seg_adaptor3d(decoder, data_loader, device, num_epochs = 3):
-    ce_loss = nn.CrossEntropyLoss()
-    optimizer = optim.Adam(decoder.parameters(), lr=1e-3)
-    # Train decoder
-    for epoch in range(num_epochs):
-        decoder.train()
-        epoch_loss = 0.0
-
-        # batch progress
-        batch_iter = tqdm(data_loader, desc=f"Epoch {epoch+1}/{num_epochs}", leave=False)
-        iteration_count = 0
-
-        for batch in batch_iter:
-            iteration_count += 1
-
-            patch_emb = batch["patch"].to(device)
-            patch_label = batch["patch_label"].to(device).long()
-
-            optimizer.zero_grad()
-            de_output = decoder(patch_emb)
-            ce = ce_loss(de_output, patch_label)  
-            dice = dice_loss(de_output, patch_label)
-            loss = ce + dice
-
-            loss.backward()
-            optimizer.step()
-
-            epoch_loss += loss.item()
-            batch_iter.set_postfix(loss=f"{loss.item():.4f}", avg=f"{epoch_loss / iteration_count:.4f}")
-
-        print(f"Epoch {epoch+1}: Avg total loss = {epoch_loss / iteration_count:.4f}")                               
-    return decoder
 
 
 
@@ -1700,3 +1303,564 @@ class ConvSegmentation3D(SegmentationUpsampling3D):
             inference_postprocessor=self.inference_postprocessor,  # overwrite original behaviour of applying sigmoid
             mask_postprocessor=self.mask_processor,
         )
+
+
+
+class LinearUpsampleConv3D(SegmentationUpsampling3D):
+    """
+    Patch-level adaptor that performs segmentation by linearly upsampling 
+    3D patch-level features followed by convolutional refinement.
+
+    This adaptor takes precomputed patch-level features from 3D medical images
+    and predicts voxel-wise segmentation by applying a simple decoder that:
+    1) linearly upsamples the patch embeddings to the original resolution, and
+    2) passes them through 3D convolution layers for spatial refinement.
+
+    Steps:
+    1. Extract patch-level segmentation labels using spatial metadata.
+    2. Construct training data from patch features and coordinates.
+    3. Train a lightweight 3D decoder that linearly upsamples features and refines them with convolution layers.
+    4. At inference, apply the decoder to test patch features and reconstruct full-size segmentation predictions.
+
+    Args:
+        shot_features : Patch-level feature embeddings of few-shot labeled volumes.
+        shot_labels : Full-resolution segmentation labels (used to supervise the decoder).
+        shot_coordinates : Patch coordinates corresponding to shot_features.
+        shot_names : Case identifiers for few-shot examples.
+        test_features : Patch-level feature embeddings for testing.
+        test_coordinates : Patch coordinates corresponding to test_features.
+        test_names : Case identifiers for testing examples.
+        test_image_sizes, test_image_origins, test_image_spacings, test_image_directions:
+            Metadata for reconstructing the spatial layout of test predictions.
+        shot_image_spacing, shot_image_origins, shot_image_directions:
+            Metadata used to align segmentation labels with patch features during training.
+        patch_size : Size of each 3D patch.
+        return_binary : Whether to threshold predictions into binary segmentation masks.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.is_task11 = False
+        self.is_task06 = False
+
+    def fit(self):
+        # build training data and loader
+        train_data = construct_data_with_labels(
+            coordinates=self.shot_coordinates,
+            embeddings=self.shot_features,
+            cases=self.shot_names,
+            patch_size=self.patch_size,
+            labels=self.shot_labels,
+        )
+        train_loader = load_patch_data(train_data, batch_size=1)
+
+        max_class = max_class_label_from_labels(self.shot_labels)
+        if max_class >= 100:
+            self.is_task11 = True
+            num_classes = 4
+        elif max_class > 1:
+            self.is_task06 = True
+            num_classes = 2
+        else:
+            num_classes = max_class + 1
+
+        # set up device and model
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        decoder = UpsampleConvSegAdaptor(
+            target_shape=self.patch_size[::-1],  # Convert to (D, H, W) order
+            num_classes=num_classes,
+        )
+        print(f"Training decoder with {num_classes} classes")
+        print(decoder)
+        decoder.to(self.device)
+        self.decoder = train_seg_adaptor3d(decoder, train_loader, self.device, is_task11=self.is_task11, is_task06=self.is_task06)
+
+    def predict(self) -> np.ndarray:
+        # build test data and loader
+        test_data = construct_data_with_labels(
+            coordinates=self.test_coordinates,
+            embeddings=self.test_features,
+            cases=self.test_cases,
+            patch_size=self.patch_size,
+            image_sizes=self.test_image_sizes,
+            image_origins=self.test_image_origins,
+            image_spacings=self.test_image_spacings,
+            image_directions=self.test_image_directions,
+        )
+
+        test_loader = load_patch_data(test_data, batch_size=1)
+        # run inference using the trained decoder
+
+        return inference3d_softmax(self.decoder, test_loader, self.device, self.return_binary, self.test_cases, self.test_label_sizes, self.test_label_spacing, self.test_label_origins, self.test_label_directions, is_task11=self.is_task11)
+
+
+class Conv3DLineaerUpsample(SegmentationUpsampling3D):
+    """
+    Patch-level adaptor that performs segmentation by linearly upsampling 
+    3D patch-level features followed by convolutional refinement.
+
+    This adaptor takes precomputed patch-level features from 3D medical images
+    and predicts voxel-wise segmentation by applying a simple decoder that:
+    1) linearly upsamples the patch embeddings to the original resolution, and
+    2) passes them through 3D convolution layers for spatial refinement.
+
+    Steps:
+    1. Extract patch-level segmentation labels using spatial metadata.
+    2. Construct training data from patch features and coordinates.
+    3. Train a lightweight 3D decoder that linearly upsamples features and refines them with convolution layers.
+    4. At inference, apply the decoder to test patch features and reconstruct full-size segmentation predictions.
+
+    Args:
+        shot_features : Patch-level feature embeddings of few-shot labeled volumes.
+        shot_labels : Full-resolution segmentation labels (used to supervise the decoder).
+        shot_coordinates : Patch coordinates corresponding to shot_features.
+        shot_names : Case identifiers for few-shot examples.
+        test_features : Patch-level feature embeddings for testing.
+        test_coordinates : Patch coordinates corresponding to test_features.
+        test_names : Case identifiers for testing examples.
+        test_image_sizes, test_image_origins, test_image_spacings, test_image_directions:
+            Metadata for reconstructing the spatial layout of test predictions.
+        shot_image_spacing, shot_image_origins, shot_image_directions:
+            Metadata used to align segmentation labels with patch features during training.
+        patch_size : Size of each 3D patch.
+        return_binary : Whether to threshold predictions into binary segmentation masks.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.is_task11 = False
+        self.is_task06 = False
+
+    def fit(self):
+        # build training data and loader
+        train_data = construct_data_with_labels(
+            coordinates=self.shot_coordinates,
+            embeddings=self.shot_features,
+            cases=self.shot_names,
+            patch_size=self.patch_size,
+            labels=self.shot_labels,
+        )
+        train_loader = load_patch_data(train_data, batch_size=1)
+
+        max_class = max_class_label_from_labels(self.shot_labels)
+        if max_class >= 100:
+            self.is_task11 = True
+            num_classes = 4
+        elif max_class > 1:
+            self.is_task06 = True
+            num_classes = 2
+        else:
+            num_classes = max_class + 1
+
+        # set up device and model
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        decoder = ConvUpsampleSegAdaptor(
+            target_shape=self.patch_size[::-1],  # Convert to (D, H, W) order
+            num_classes=num_classes,
+        )
+        print(f"Training decoder with {num_classes} classes")
+        print(decoder)
+        decoder.to(self.device)
+        self.decoder = train_seg_adaptor3d(decoder, train_loader, self.device, is_task11=self.is_task11, is_task06=self.is_task06)
+
+    def predict(self) -> np.ndarray:
+        # build test data and loader
+        test_data = construct_data_with_labels(
+            coordinates=self.test_coordinates,
+            embeddings=self.test_features,
+            cases=self.test_cases,
+            patch_size=self.patch_size,
+            image_sizes=self.test_image_sizes,
+            image_origins=self.test_image_origins,
+            image_spacings=self.test_image_spacings,
+            image_directions=self.test_image_directions,
+        )
+
+        test_loader = load_patch_data(test_data, batch_size=1)
+        # run inference using the trained decoder
+
+        return inference3d_softmax(self.decoder, test_loader, self.device, self.return_binary, self.test_cases, self.test_label_sizes, self.test_label_spacing, self.test_label_origins, self.test_label_directions, is_task11=self.is_task11)
+
+
+def expand_instance_labels(y: np.ndarray) -> np.ndarray:
+    """
+    Reverse-expand class labels to instance labels.
+
+    Input y uses:
+      - 0: background
+      - 1: class-A (-> instances 1..99)
+      - 2: class-B (-> 100)
+      - 3: class-C (-> instances 201..)
+
+    Rules:
+      - label==1 -> connected components -> 1,2,3,... up to 99 (100th+ capped at 99)
+      - label==2 -> 100
+      - label==3 -> connected components -> 201,202,...
+      - else     -> 0
+    """
+    y = y.astype(np.int64, copy=False)
+    out = np.zeros_like(y, dtype=np.int64)
+
+    # Connectivity: 2D=8, 3D=26
+    structure = np.ones((3,) * y.ndim, dtype=np.uint8)
+
+    # --- label==1 ---
+    mask1 = (y == 1)
+    if np.any(mask1):
+        lbl1, n1 = ndi.label(mask1, structure=structure)
+        next_lab = 1
+        for cid in range(1, n1 + 1):
+            blob = (lbl1 == cid)
+            if not np.any(blob):
+                continue
+            assign = next_lab if next_lab <= 99 else 99
+            out[blob] = assign
+            next_lab += 1
+
+    # --- label==2 ---
+    out[y == 2] = 100
+
+    # --- label==3 ---
+    mask3 = (y == 3)
+    if np.any(mask3):
+        lbl3, n3 = ndi.label(mask3, structure=structure)
+        base = 201
+        for cid in range(1, n3 + 1):
+            blob = (lbl3 == cid)
+            if not np.any(blob):
+                continue
+            out[blob] = base
+            base += 1
+
+    return out
+
+
+def inference3d_softmax(decoder, data_loader, device, return_binary,  test_cases, test_label_sizes, test_label_spacing, test_label_origins, test_label_directions, is_task11=False):
+    decoder.eval()
+    with torch.no_grad():
+        grouped_predictions = defaultdict(lambda: defaultdict(list))
+
+        for batch in data_loader:
+            inputs = batch["patch"].to(device)  # shape: [B, ...]
+            coords = batch["coordinates"]  # list of 3 tensors
+            image_idxs = batch["case_number"]
+
+            outputs = decoder(inputs)  # shape: [B, ...]
+            probs = torch.softmax(outputs, dim=1)
+
+            if return_binary:
+                pred_mask = torch.argmax(probs, dim=1, keepdim=True).float()
+            else:
+                pred_mask = probs[:, 1:]
+
+            batch["image_origin"] = batch["image_origin"][0]
+            batch["image_spacing"] = batch["image_spacing"][0]
+            for i in range(len(image_idxs)):
+                image_id = int(image_idxs[i])
+                coord = tuple(
+                    float(c) for c in coords[i]
+                )  # convert list to tuple for use as dict key
+                grouped_predictions[image_id][coord].append(
+                    {
+                        "features": pred_mask[i].cpu().numpy(),
+                        "patch_size": [
+                            int(batch["patch_size"][j][i])
+                            for j in range(len(batch["patch_size"]))
+                        ],
+                        "image_size": [
+                            int(batch["image_size"][j][i])
+                            for j in range(len(batch["image_size"]))
+                        ],
+                        "image_origin": [
+                            float(batch["image_origin"][j][i])
+                            for j in range(len(batch["image_origin"]))
+                        ],
+                        "image_spacing": [
+                            float(batch["image_spacing"][j][i])
+                            for j in range(len(batch["image_spacing"]))
+                        ],
+                        "image_direction": [
+                            float(batch["image_direction"][j][i])
+                            for j in range(len(batch["image_direction"]))
+                        ],
+                    }
+                )
+
+        averaged_patches = defaultdict(list)
+
+        for image_id, coord_dict in grouped_predictions.items():
+            for coord, patches in coord_dict.items():
+                all_features = [p["features"] for p in patches]
+                stacked = np.stack(all_features, axis=0)
+                avg_features = np.mean(stacked, axis=0)
+
+                averaged_patches[image_id].append(
+                    {
+                        "coord": list(coord),
+                        "features": avg_features,
+                        "patch_size": patches[0]["patch_size"],
+                        "image_size": patches[0]["image_size"],
+                        "image_origin": patches[0]["image_origin"],
+                        "image_spacing": patches[0]["image_spacing"],
+                        "image_direction": patches[0]["image_direction"],
+                    }
+                )
+        
+        grids = create_grid(averaged_patches)
+
+        aligned_preds = {}
+
+        for case_id, pred_msk in grids.items():
+            case = test_cases[case_id]
+            gt_size = test_label_sizes[case]
+            gt_spacing = test_label_spacing[case]
+            gt_origin = test_label_origins[case]
+            gt_direction = test_label_directions[case]
+
+            pred_on_gt = sitk.Resample(
+                pred_msk,
+                gt_size,
+                sitk.Transform(),
+                sitk.sitkNearestNeighbor,
+                gt_origin,
+                gt_spacing,
+                gt_direction
+            )
+            
+            if is_task11:
+                pred_on_gt_arr = sitk.GetArrayFromImage(pred_on_gt)
+                aligned_preds[case_id] = expand_instance_labels(pred_on_gt_arr)
+            else:
+                aligned_preds[case_id] = sitk.GetArrayFromImage(pred_on_gt)
+            
+        return [j for j in aligned_preds.values()]
+
+
+def max_class_label_from_labels(label_patch_features) -> int:
+    """
+    Find the maximum class label across all patches.
+    Returns the maximum label value, or 0 if none found.
+    """
+    mx = -1
+    for case in label_patch_features:
+        for p in case.get("patches", []):
+            a = np.asarray(p.get("features", ()))
+            if a.size == 0:
+                continue
+            v = np.nanmax(a)
+            if np.isfinite(v) and v > mx:
+                mx = int(v)
+    return mx if mx >= 0 else 0
+
+def remap_task11_labels(label_patch_features):
+    """
+    Remap feature labels in-place if this is Task 11.
+
+    Input
+    -----
+    label_patch_features : np.array(dtype=object)
+        Array of "cases". Each case is a dict with:
+          - 'patches': list of dicts, where each dict has:
+              - 'features': np.ndarray (e.g., shape 128x128x16)
+
+    Logic
+    -----
+    1) Determine Task 11:
+       - Scan all feature arrays and compute a global maximum.
+       - If global_max >= 100, treat as Task 11 and apply remapping.
+
+    2) Remapping rules (apply only when Task 11):
+       - values in (0, 100)  -> 1
+       - values == 100       -> 2
+       - values > 200        -> 3
+       - all other values (e.g., 0, 101–200, 200) remain unchanged.
+
+    Returns
+    -------
+    dict with keys:
+      - 'is_task11': bool
+      - 'global_max': float or int or None
+      - 'changed_patches': int, number of patches updated
+    """
+    # --- Step 1: compute global maximum across all features ---
+    global_max = None
+    for case in label_patch_features:
+        for p in case.get("patches", []):
+            feats = p.get("features", None)
+            if feats is None:
+                continue
+            arr = np.asarray(feats)
+            if arr.size == 0:
+                continue
+            m = arr.max()
+            global_max = m if global_max is None else max(global_max, m)
+
+    is_task11 = (global_max is not None) and (global_max >= 100)
+    if not is_task11:
+        return {"is_task11": False, "global_max": global_max, "changed_patches": 0}
+
+    # --- Step 2: apply in-place remapping for Task 11 ---
+    changed = 0
+    for case in label_patch_features:
+        for p in case.get("patches", []):
+            feats = p.get("features", None)
+            if feats is None:
+                continue
+            arr = np.asarray(feats)
+            if arr.size == 0:
+                continue
+
+            orig_dtype = arr.dtype
+            mapped = arr.copy()
+
+            # Build masks for each rule
+            mask1 = (mapped > 0) & (mapped < 100)
+            mask2 = (mapped == 100)
+            mask3 = (mapped > 200)
+
+            if mask1.any() or mask2.any() or mask3.any():
+                mapped[mask1] = 1
+                mapped[mask2] = 2
+                mapped[mask3] = 3
+
+                # Preserve original dtype and write back
+                p["features"] = mapped.astype(orig_dtype, copy=False)
+                changed += 1
+
+    return {"is_task11": True, "global_max": global_max, "changed_patches": changed}
+
+def map_labels(y: torch.Tensor) -> torch.Tensor:
+    """
+    Rules:
+      - y == 100      -> 2
+      - 1 <= y <= 99  -> 1
+      - y >= 201      -> 3
+      - else          -> 0
+    """
+
+    y_new = torch.zeros_like(y)
+
+    y_new = torch.where(y == 100, 2, y_new)
+    y_new = torch.where((y >= 1) & (y <= 99), 1, y_new)
+    y_new = torch.where(y >= 201, 3, y_new)
+
+    return y_new
+
+
+def train_seg_adaptor3d(decoder, data_loader, device, num_epochs = 3, is_task11=False, is_task06=False):
+    ce_loss = nn.CrossEntropyLoss()
+    optimizer = optim.Adam(decoder.parameters(), lr=1e-3)
+    # Train decoder
+    for epoch in range(num_epochs):
+        decoder.train()
+        epoch_loss = 0.0
+
+        # batch progress
+        batch_iter = tqdm(data_loader, desc=f"Epoch {epoch+1}/{num_epochs}", leave=False)
+        iteration_count = 0
+    
+        for batch in batch_iter:
+            iteration_count += 1
+
+            patch_emb = batch["patch"].to(device)
+            patch_label = batch["patch_label"].to(device).long()
+
+            if is_task11 or is_task06:
+                patch_label = map_labels(patch_label)
+
+
+            optimizer.zero_grad()
+            de_output = decoder(patch_emb) 
+
+            ce = ce_loss(de_output, patch_label) 
+            if is_task06:
+                loss = ce
+            else:
+                dice = dice_loss(de_output, patch_label)
+                loss = ce + dice
+
+            loss.backward()
+            optimizer.step()
+
+            epoch_loss += loss.item()
+
+            # tqdm description 
+            batch_iter.set_postfix(loss=f"{loss.item():.4f}", avg=f"{epoch_loss / iteration_count:.4f}")
+
+        print(f"Epoch {epoch+1}: Avg total loss = {epoch_loss / iteration_count:.4f}")                               
+
+
+    return decoder
+
+
+
+class UpsampleConvSegAdaptor(nn.Module):
+    def __init__(self, target_shape=None, in_channels=32, num_classes=2):
+        super().__init__()
+        self.target_shape = target_shape
+        self.in_channels = in_channels
+        # Two intermediate conv layers + final prediction layer
+        self.conv_blocks = nn.Sequential(
+            nn.Conv3d(in_channels, in_channels, kernel_size=3, padding=1),
+            nn.ReLU(inplace=True),
+            nn.Conv3d(in_channels, in_channels, kernel_size=3, padding=1),
+            nn.ReLU(inplace=True),
+            nn.Conv3d(in_channels, num_classes, kernel_size=1)
+        )
+
+    def forward(self, x):
+        C = self.in_channels
+        B = x.shape[0]
+        flat_voxel_count = x.shape[1] // C
+
+        D_ref, H_ref, W_ref = self.target_shape
+        ref_ratio = D_ref * H_ref * W_ref
+
+        k = (flat_voxel_count / ref_ratio) ** (1 / 3)
+
+        D = round(D_ref * k)
+        H = round(H_ref * k)
+        W = round(W_ref * k)
+
+        x = x.view(B, C, D, H, W)
+        x = F.interpolate(x, size=self.target_shape, mode="trilinear", align_corners=False)
+        x = self.conv_blocks(x)
+        return x
+
+
+class ConvUpsampleSegAdaptor(nn.Module):
+    def __init__(self, target_shape=None, in_channels=32, num_classes=2):
+        super().__init__()
+        self.target_shape = target_shape
+        self.in_channels = in_channels
+        self.conv_blocks = nn.Sequential(
+            nn.Conv3d(in_channels, num_classes, kernel_size=3, padding=1) 
+        )
+
+    def forward(self, x):
+        C = self.in_channels
+        B = x.shape[0]
+        flat_voxel_count = x.shape[1] // C
+
+        D_ref, H_ref, W_ref = self.target_shape
+        ref_ratio = D_ref * H_ref * W_ref
+
+        k = (flat_voxel_count / ref_ratio) ** (1 / 3)
+
+        D = round(D_ref * k)
+        H = round(H_ref * k)
+        W = round(W_ref * k)
+
+        x = x.view(B, C, D, H, W)
+        x = self.conv_blocks(x)
+        x = F.interpolate(x, size=self.target_shape, mode="trilinear", align_corners=False)
+        return x
+
+def dice_loss(pred, target, smooth=1e-5):
+    num_classes = pred.shape[1]
+    pred = F.softmax(pred, dim=1)
+    one_hot_target = F.one_hot(target, num_classes=num_classes).permute(0, 4, 1, 2, 3).float()
+
+    intersection = torch.sum(pred * one_hot_target, dim=(2, 3, 4))
+    union = torch.sum(pred + one_hot_target, dim=(2, 3, 4))
+
+    dice = (2 * intersection + smooth) / (union + smooth)
+    return 1 - dice.mean()

--- a/src/unicorn_eval/utils.py
+++ b/src/unicorn_eval/utils.py
@@ -34,6 +34,7 @@ from unicorn_eval.adaptors import (
     SegmentationUpsampling3D,
     ConvSegmentation3D,
     LinearUpsampleConv3D,
+    Conv3DLineaerUpsample,
     WeightedKNN,
     WeightedKNNRegressor,
 )
@@ -342,9 +343,34 @@ def adapt_features(
             test_image_sizes=test_image_sizes,
             patch_size=patch_size[0],
         )
-
     elif adaptor_name == "linear-upsample-conv3d":
         adaptor = LinearUpsampleConv3D(
+            shot_features=shot_features,
+            shot_coordinates=shot_coordinates,
+            shot_names=shot_names,
+            shot_labels=shot_labels,
+            shot_label_spacing=shot_label_spacing,
+            shot_label_origins=shot_label_origins,
+            shot_label_directions=shot_label_directions,
+            test_features=test_features,
+            test_coordinates=test_coordinates,
+            test_names=test_names,  # try to remove this input
+            test_image_sizes=test_image_sizes,
+            test_image_origins=test_image_origins,
+            test_image_spacings=test_image_spacing,
+            test_image_directions=test_image_directions,
+            test_label_sizes=test_label_sizes,
+            test_label_spacing=test_label_spacing,
+            test_label_origins=test_label_origins,
+            test_label_directions=test_label_directions,
+            patch_size=patch_size,
+            shot_image_sizes=shot_image_sizes,
+            shot_image_spacing=shot_image_spacing,
+            shot_image_origins=shot_image_origins,
+            shot_image_directions=shot_image_directions,
+        )
+    elif adaptor_name == "conv3d-linear-upsample":
+        adaptor = Conv3DLineaerUpsample(
             shot_features=shot_features,
             shot_coordinates=shot_coordinates,
             shot_names=shot_names,
@@ -422,6 +448,62 @@ def adapt_features(
             shot_image_spacing=shot_image_spacing,
             shot_image_origins=shot_image_origins,
             shot_image_directions=shot_image_directions,
+        )
+
+    elif adaptor_name == "detection-by-linear-upsample-conv3d":
+        adaptor = LinearUpsampleConv3D(
+            shot_features=shot_features,
+            shot_coordinates=shot_coordinates,
+            shot_names=shot_names,
+            shot_image_sizes=shot_image_sizes,
+            shot_image_spacing=shot_image_spacing,
+            shot_image_origins=shot_image_origins,
+            shot_image_directions=shot_image_directions,
+            shot_labels=shot_labels,
+            shot_label_spacing=shot_label_spacing,
+            shot_label_origins=shot_label_origins,
+            shot_label_directions=shot_label_directions,
+            test_features=test_features,
+            test_coordinates=test_coordinates,
+            test_names=test_names,
+            test_image_sizes=test_image_sizes,
+            test_image_origins=test_image_origins,
+            test_image_spacings=test_image_spacing,
+            test_image_directions=test_image_directions,
+            test_label_sizes=test_label_sizes,
+            test_label_spacing=test_label_spacing,
+            test_label_origins=test_label_origins,
+            test_label_directions=test_label_directions,
+            patch_size=patch_size,
+            return_binary=False,
+        )
+
+    elif adaptor_name == "detection-by-conv3d-linear-upsample":
+        adaptor = Conv3DLineaerUpsample(
+            shot_features=shot_features,
+            shot_coordinates=shot_coordinates,
+            shot_names=shot_names,
+            shot_image_sizes=shot_image_sizes,
+            shot_image_spacing=shot_image_spacing,
+            shot_image_origins=shot_image_origins,
+            shot_image_directions=shot_image_directions,
+            shot_labels=shot_labels,
+            shot_label_spacing=shot_label_spacing,
+            shot_label_origins=shot_label_origins,
+            shot_label_directions=shot_label_directions,
+            test_features=test_features,
+            test_coordinates=test_coordinates,
+            test_names=test_names,
+            test_image_sizes=test_image_sizes,
+            test_image_origins=test_image_origins,
+            test_image_spacings=test_image_spacing,
+            test_image_directions=test_image_directions,
+            test_label_sizes=test_label_sizes,
+            test_label_spacing=test_label_spacing,
+            test_label_origins=test_label_origins,
+            test_label_directions=test_label_directions,
+            patch_size=patch_size,
+            return_binary=False,
         )
 
     elif adaptor_name == "detection-by-segmentation-upsampling-3d":


### PR DESCRIPTION
This PR improves the flexibility and performance of the LinearUpsampleConv3D module by making it more generic and aligning its behavior with the original SegmentationUpsampling3D.

Key changes:

The LinearUpsampleConv3D class now inherits from SegmentationUpsampling3D, removing the need for manual resampling logic. It correctly supports both multi-task settings (for Task 11) and binary segmentation (via return_binary=True, used in Task 6).

A lightweight variant, Conv3DLinearUpsample, has been added. This performs Conv3D before upsampling and significantly improves runtime performance. It gives users additional flexibility for architectural choices.

The utils.py file has been updated to include branching logic for both:

detection-by-conv3d-linear-upsample
detection-by-linear-upsample-conv3d
conv3d-linear-upsample

This update has been locally tested on Task 06, Task 10, and Task 11.