### PR TITLE
missing patch_spacing argument hotfix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ warn_unused_configs = true
 no_implicit_reexport = true
 
 [tool.bumpver]
-current_version = "1.5.0"
+current_version = "1.6.0"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit = false       # We do version bumping in CI, not as a commit
 tag = false          # Git tag already exists — we don't auto-tag

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = unicorn_eval
-version = 1.5.0
+version = 1.6.0
 description = Evaluation and adaption method for the UNICORN Challenge
 author = Joeran Bosma, Clément Grisi, Marina D`Amato, Luc Builtjes, Lena Philipp, Fennie van der Graaf, Judith Lefkes, Michelle Stegeman, Rianne Weber
 platforms = unix, linux, osx, cygwin, win32

--- a/src/unicorn_eval/__init__.py
+++ b/src/unicorn_eval/__init__.py
@@ -12,4 +12,4 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-__version__ = "1.5.0"
+__version__ = "1.6.0"

--- a/src/unicorn_eval/utils.py
+++ b/src/unicorn_eval/utils.py
@@ -505,6 +505,7 @@ def adapt_features(
             test_label_origins=test_label_origins,
             test_label_directions=test_label_directions,
             patch_size=patch_size,
+            patch_spacing=patch_spacing,
             return_binary=False,
         )
 
@@ -533,6 +534,7 @@ def adapt_features(
             test_label_origins=test_label_origins,
             test_label_directions=test_label_directions,
             patch_size=patch_size,
+            patch_spacing=patch_spacing,
             return_binary=False,
             decoder=ConvUpsampleSegAdaptor,
         )

--- a/tests/vision/input/adaptor-radiology-detection-segmentation.json
+++ b/tests/vision/input/adaptor-radiology-detection-segmentation.json
@@ -1,1 +1,1 @@
-"segmentation-upsampling-3d"
+"detection-by-linear-upsample-conv3d"


### PR DESCRIPTION
`patch_spacing` was missing in a few calls depending on the `SegmentationUpsampling3D` class