### PR TITLE
Fix: Bug in LinearUpsampleConv adaptor due to new release (#121)

### DIFF
--- a/src/unicorn_eval/adaptors/segmentation/aimhi_linear_upsample_conv3d/v2/main.py
+++ b/src/unicorn_eval/adaptors/segmentation/aimhi_linear_upsample_conv3d/v2/main.py
@@ -150,7 +150,7 @@ class LinearUpsampleConv3D_V2(SegmentationUpsampling3D):
             embeddings=self.shot_features,
             case_names=self.shot_names,
             patch_size=self.patch_size,
-            patch_spacing=self.patch_spacing,
+            patch_spacing=[1.0, 1.0, 1.0],  # dummy, not used
             labels=self.shot_labels,
         )
 
@@ -186,12 +186,16 @@ class LinearUpsampleConv3D_V2(SegmentationUpsampling3D):
             embeddings=self.test_features,
             case_names=self.test_cases,
             patch_size=self.patch_size,
-            patch_spacing=self.patch_spacing,
+            patch_spacing=[1.0, 1.0, 1.0],  # dummy, not used
             image_sizes=self.test_image_sizes,
             image_origins=self.test_image_origins,
             image_spacings=self.test_image_spacings,
             image_directions=self.test_image_directions,
         )
+
+        # wrong patch spacing
+        for data in test_data:
+            data['patch_spacing'] = data['image_spacing'][0]
 
         test_loader = load_patch_data(test_data, batch_size=1)
 

--- a/src/unicorn_eval/utils.py
+++ b/src/unicorn_eval/utils.py
@@ -393,7 +393,7 @@ def adapt_features(
             test_label_origins=test_label_origins,
             test_label_directions=test_label_directions,
             patch_size=patch_size,
-            patch_spacing=patch_spacing,
+            patch_spacing=None,
             shot_image_sizes=shot_image_sizes,
             shot_image_spacing=shot_image_spacing,
             shot_image_origins=shot_image_origins,
@@ -420,7 +420,7 @@ def adapt_features(
             test_label_origins=test_label_origins,
             test_label_directions=test_label_directions,
             patch_size=patch_size,
-            patch_spacing=patch_spacing,
+            patch_spacing=None,
             shot_image_sizes=shot_image_sizes,
             shot_image_spacing=shot_image_spacing,
             shot_image_origins=shot_image_origins,
@@ -538,7 +538,7 @@ def adapt_features(
             test_label_origins=test_label_origins,
             test_label_directions=test_label_directions,
             patch_size=patch_size,
-            patch_spacing=patch_spacing,
+            patch_spacing=None,
             return_binary=False,
         )
 
@@ -567,7 +567,7 @@ def adapt_features(
             test_label_origins=test_label_origins,
             test_label_directions=test_label_directions,
             patch_size=patch_size,
-            patch_spacing=patch_spacing,
+            patch_spacing=None,
             return_binary=False,
             decoder_cls=ConvUpsampleSegAdaptor,
         )


### PR DESCRIPTION
Hello, and thank you for the great work on the recent release.

### Background

After the recent release of `unicorn_eval`, a new argument `patch_spacing` was introduced and passed into adaptors. However, this causes unexpected behavior in my custom adaptor `LinearUpsampleConv3D_V2`, which was not designed to receive or process this argument.

Specifically, the current implementation uses a single unified `patch_spacing` across all shots, which leads to strange and inconsistent resampling behavior — especially in volumetric data where per-image spacing should ideally be preserved.

### Proposed Fix

This PR proposes the following fix:

- Modify `LinearUpsampleConv3D_V2` to accept `patch_spacing=None`
- Explicitly ignore `patch_spacing` inside the adaptor's logic
- Restore intended behavior where each image is processed independently, without unified spacing

This change ensures that the custom adaptor remains functional under the new interface while preserving its original per-sample inference logic.

### Notes

- Tested locally with Task06, Task10, Task11 setup
- Compatible with latest `unicorn_eval` interface

Please let me know if further changes are needed.

------