### PR TITLE
undo change to pathology segmentation adaptor type

### DIFF
--- a/src/unicorn_eval/adaptors/segmentation/baseline_segmentation_upsampling_3d/v1/main.py
+++ b/src/unicorn_eval/adaptors/segmentation/baseline_segmentation_upsampling_3d/v1/main.py
@@ -99,7 +99,7 @@ class SegmentationUpsampling(PatchLevelTaskAdaptor):
             )
             predictions.extend(predicted_masks)
 
-        return np.array(predictions)
+        return predictions
 
 
 class SegmentationUpsampling3D(PatchLevelTaskAdaptor):


### PR DESCRIPTION
Made a minor adjustment to the predictions type in the pathology segmentation adaptor. Using a NumPy array causes errors since it cannot contain arrays of differing shapes, so it should remain a list