### PR TITLE
fix adaptors

### DIFF
--- a/src/unicorn_eval/adaptors/regression.py
+++ b/src/unicorn_eval/adaptors/regression.py
@@ -322,7 +322,7 @@ class LinearProbingRegressor(CaseLevelTaskAdaptor):
             logits = self.model(shot_features)
             if self.survival:
                 hazards = torch.sigmoid(logits)  # [B, nbins]
-                survival = torch.cumprod(1 - hazards, dim=0)  # [B, nbins]
+                survival = torch.cumprod(1 - hazards, dim=-1)  # [B, nbins]
                 loss = self.criterion(hazards, survival, shot_labels, censoring)
             else:
                 loss = self.criterion(logits, shot_labels)
@@ -360,8 +360,8 @@ class LinearProbingRegressor(CaseLevelTaskAdaptor):
                 logits = self.model(test_features)
                 if self.survival:
                     hazards = torch.sigmoid(logits)
-                    survival = torch.cumprod(1 - hazards, dim=0)
-                    risk_scores = -torch.sum(survival, dim=0)
+                    survival = torch.cumprod(1 - hazards, dim=-1)
+                    risk_scores = -torch.sum(survival, dim=-1)
                     prediction = -risk_scores
                     predictions.append(prediction.cpu().numpy())
                 else:
@@ -486,7 +486,7 @@ class MultiLayerPerceptronRegressor(CaseLevelTaskAdaptor):
             logits = self.model(shot_features)
             if self.survival:
                 hazards = torch.sigmoid(logits)  # [B, nbins]
-                survival = torch.cumprod(1 - hazards, dim=0)  # [B, nbins]
+                survival = torch.cumprod(1 - hazards, dim=-1)  # [B, nbins]
                 loss = self.criterion(hazards, survival, shot_labels, censoring)
             else:
                 loss = self.criterion(logits, shot_labels)
@@ -524,8 +524,8 @@ class MultiLayerPerceptronRegressor(CaseLevelTaskAdaptor):
                 logits = self.model(test_features)
                 if self.survival:
                     hazards = torch.sigmoid(logits)
-                    survival = torch.cumprod(1 - hazards, dim=0)
-                    risk_scores = -torch.sum(survival, dim=0)
+                    survival = torch.cumprod(1 - hazards, dim=-1)
+                    risk_scores = -torch.sum(survival, dim=-1)
                     prediction = -risk_scores
                     predictions.append(prediction.cpu().numpy())
                 else:

--- a/src/unicorn_eval/adaptors/regression.py
+++ b/src/unicorn_eval/adaptors/regression.py
@@ -297,7 +297,7 @@ class LinearProbingRegressor(CaseLevelTaskAdaptor):
             shot_labels = torch.tensor(shot_labels, dtype=torch.long).to(self.device)
             censoring = torch.tensor(censoring, dtype=torch.long).to(self.device)
         else:
-            shot_labels = torch.tensor(shot_labels, dtype=torch.float32).to(self.device)
+            shot_labels = torch.tensor(shot_labels, dtype=torch.float32).to(self.device).unsqueeze(1)
 
         self.model = LinearClassifier(input_dim, self.num_classes).to(self.device)
         self.optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate)
@@ -459,7 +459,7 @@ class MultiLayerPerceptronRegressor(CaseLevelTaskAdaptor):
             shot_labels = torch.tensor(shot_labels, dtype=torch.long).to(self.device)
             censoring = torch.tensor(censoring, dtype=torch.long).to(self.device)
         else:
-            shot_labels = torch.tensor(shot_labels, dtype=torch.float32).to(self.device)
+            shot_labels = torch.tensor(shot_labels, dtype=torch.float32).to(self.device).unsqueeze(1)
 
         self.model = MLPClassifier(
             input_dim, self.hidden_dim, self.num_classes, self.num_layers

--- a/src/unicorn_eval/adaptors/regression.py
+++ b/src/unicorn_eval/adaptors/regression.py
@@ -87,7 +87,7 @@ class KNNRegressor(CaseLevelTaskAdaptor):
 
     def fit(self, shot_features, shot_labels, **kwargs):
         self.mean_feature = shot_features.mean(axis=0, keepdims=True)
-        shot_features, _ = preprocess_features(
+        shot_features = preprocess_features(
             shot_features,
             center=self.center_features,
             mean=self.mean_feature,

--- a/src/unicorn_eval/adaptors/segmentation/inference.py
+++ b/src/unicorn_eval/adaptors/segmentation/inference.py
@@ -67,26 +67,30 @@ def inference(decoder, dataloader, patch_size, test_image_sizes=None):
         if case not in predicted_masks:
             case_image_size = test_image_sizes.get(case, None)
             if case_image_size is not None:
-                predicted_masks[case] = np.zeros(case_image_size, dtype=np.float32)
+                width, height = case_image_size
+                predicted_masks[case] = np.zeros((height, width), dtype=np.float32)
             else:
                 raise ValueError(f"Image size not found for case {case}")
 
-        max_x = min(x + patch_size, predicted_masks[case].shape[0])
-        max_y = min(y + patch_size, predicted_masks[case].shape[1])
-        slice_width = max_x - x
-        slice_height = max_y - y
+        height, width = predicted_masks[case].shape
+        x0 = int(x)
+        y0 = int(y)
+        x1 = min(x0 + patch_size, width)
+        y1 = min(y0 + patch_size, height)
+        slice_width = x1 - x0
+        slice_height = y1 - y0
 
         if slice_height > 0 and slice_width > 0:
-            pred_masks_resized = pred_masks[:slice_width, :slice_height]
+            pred_masks_resized = pred_masks[:slice_height, :slice_width]
             predicted_masks[case][
-                x : x + slice_width, y : y + slice_height
+                y0:y1, x0:x1
             ] = pred_masks_resized
         else:
             logging.warning(
                 f"Skipping assignment for case {case} at ({x}, {y}) due to invalid slice size"
             )
 
-    return [v.T for v in predicted_masks.values()]
+    return list(predicted_masks.values())
 
 
 def world_to_voxel(coord, origin, spacing, inv_direction):


### PR DESCRIPTION
## Summary

Fixes four issues in vision adaptors:

  - `KNNRegressor.fit` incorrectly unpacked the return value of `preprocess_features`, which returns a single array.
  - Non-survival `LinearProbingRegressor` and `MultiLayerPerceptronRegressor` passed `[B]` labels to `MSELoss` against `[B, 1]` model outputs, causing unintended broadcasting.
  - Survival `LinearProbingRegressor` and `MultiLayerPerceptronRegressor` computed cumulative survival along `dim=0`. During training, logits are `[num_shots, nbins]`, so this ran the cumulative product
  across shots instead of survival bins. This now uses `dim=-1`.
  - 2D segmentation inference stitched patch predictions with swapped axes. Task 9 `image-size` is `[width, height]`, while NumPy masks are `[height, width]`; inference now allocates `(height, width)`,
  writes patches with `[y, x]` indexing, and no longer transposes the final mask.

  ## Impact

- the `KNNRegressor` bug can cause fitting to fail for 3+ shots, or behave incorrectly with exactly 2 shots.

- the non-survival MSE broadcasting issue is serious for non-survival regression because it changes the objective from per-sample regression to effectively pushing all predictions toward the batch mean label. However, the practical impact should be limited as our sole regression task is a survival prediction task, so we have not used these non-survival regression heads.

- the survival axis issue affects the training objective for survival regression heads. Prediction did not generally crash because case-level test embeddings are passed one case at a time as a 1D vector, where `dim=0` happened to be the bin axis. Training, however, uses all shots as `[num_shots, nbins]`, so the survival/censoring part of the loss was batch-order dependent.

- the 2D segmentation issue affects `segmentation-upsampling` for Task 9. On square-ish data this can be partially masked by the final transpose, but local patch content is transposed and non-square images or edge patches can be cropped/placed incorrectly.